### PR TITLE
feat(outbound): support reality in anytls

### DIFF
--- a/adapter/outbound/anytls.go
+++ b/adapter/outbound/anytls.go
@@ -9,6 +9,7 @@ import (
 	CN "github.com/metacubex/mihomo/common/net"
 	"github.com/metacubex/mihomo/component/dialer"
 	"github.com/metacubex/mihomo/component/proxydialer"
+	tlsC "github.com/metacubex/mihomo/component/tls"
 	C "github.com/metacubex/mihomo/constant"
 	"github.com/metacubex/mihomo/transport/anytls"
 	"github.com/metacubex/mihomo/transport/vmess"
@@ -26,20 +27,21 @@ type AnyTLS struct {
 
 type AnyTLSOption struct {
 	BasicOption
-	Name                     string     `proxy:"name"`
-	Server                   string     `proxy:"server"`
-	Port                     int        `proxy:"port"`
-	Password                 string     `proxy:"password"`
-	ALPN                     []string   `proxy:"alpn,omitempty"`
-	SNI                      string     `proxy:"sni,omitempty"`
-	ECHOpts                  ECHOptions `proxy:"ech-opts,omitempty"`
-	ClientFingerprint        string     `proxy:"client-fingerprint,omitempty"`
-	SkipCertVerify           bool       `proxy:"skip-cert-verify,omitempty"`
-	Fingerprint              string     `proxy:"fingerprint,omitempty"`
-	UDP                      bool       `proxy:"udp,omitempty"`
-	IdleSessionCheckInterval int        `proxy:"idle-session-check-interval,omitempty"`
-	IdleSessionTimeout       int        `proxy:"idle-session-timeout,omitempty"`
-	MinIdleSession           int        `proxy:"min-idle-session,omitempty"`
+	Name                     string         `proxy:"name"`
+	Server                   string         `proxy:"server"`
+	Port                     int            `proxy:"port"`
+	Password                 string         `proxy:"password"`
+	ALPN                     []string       `proxy:"alpn,omitempty"`
+	SNI                      string         `proxy:"sni,omitempty"`
+	ECHOpts                  ECHOptions     `proxy:"ech-opts,omitempty"`
+	RealityOpts              RealityOptions `proxy:"reality-opts,omitempty"`
+	ClientFingerprint        string         `proxy:"client-fingerprint,omitempty"`
+	SkipCertVerify           bool           `proxy:"skip-cert-verify,omitempty"`
+	Fingerprint              string         `proxy:"fingerprint,omitempty"`
+	UDP                      bool           `proxy:"udp,omitempty"`
+	IdleSessionCheckInterval int            `proxy:"idle-session-check-interval,omitempty"`
+	IdleSessionTimeout       int            `proxy:"idle-session-timeout,omitempty"`
+	MinIdleSession           int            `proxy:"min-idle-session,omitempty"`
 }
 
 func (t *AnyTLS) DialContext(ctx context.Context, metadata *C.Metadata) (_ C.Conn, err error) {
@@ -115,6 +117,11 @@ func NewAnyTLS(option AnyTLSOption) (*AnyTLS, error) {
 	if err != nil {
 		return nil, err
 	}
+	var realityConfig *tlsC.RealityConfig
+	realityConfig, err = option.RealityOpts.Parse()
+	if err != nil {
+		return nil, err
+	}
 	tlsConfig := &vmess.TLSConfig{
 		Host:              option.SNI,
 		SkipCertVerify:    option.SkipCertVerify,
@@ -122,6 +129,7 @@ func NewAnyTLS(option AnyTLSOption) (*AnyTLS, error) {
 		FingerPrint:       option.Fingerprint,
 		ClientFingerprint: option.ClientFingerprint,
 		ECH:               echConfig,
+		Reality:           realityConfig,
 	}
 	if tlsConfig.Host == "" {
 		tlsConfig.Host = option.Server


### PR DESCRIPTION
## Summary
- forward `reality-opts` into AnyTLS TLSConfig

## Testing
- `go build -o mihomo`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68babcb38880832ea72ed11f0335169b